### PR TITLE
add path.matches_ignore_case

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,8 @@ easier to type in a hurry.
   - `ext`       extension of file path
   - `file_name` file name part of path
 
-There's also a `matches` method (e.g. `path.matches("*/readme.*")`).
+There's also a `matches` method (e.g. `path.matches("*/readme.*")`),
+and an ASCII-case-insensitive counterpart `matches_ignore_case`.
 
 `date` has the following methods:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,8 @@ path has the following fields:
   * file_name file name part of path
 
 And the method:
-  * matches   path matches wildcard
+  * matches              path matches wildcard
+  * matches_ignore_case  path matches wildcard, ignoring ASCII case
 
 date has the following methods:
   * before(datestr)  all files modified before this date

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ $ FINDR_US=1 findr . 'date.on("last 9/11")'
 
 use ignore::{WalkBuilder, DirEntry};
 use rhai::{Engine,Scope,RegisterFn};
-use glob::Pattern;
+use glob::{MatchOptions, Pattern};
 
 mod errors;
 use errors::*;
@@ -87,11 +87,21 @@ fn file_name(entry: &DirEntry) -> &str {
     entry.file_name().to_str().unwrap_or(&"?")
 }
 
+#[derive(Clone, Debug)]
+/// Facade for `glob::MatchOptions.case_sensitive`
+///
+/// Since `glob::MatchOptions` doesn't implement `Debug`, we can't put
+/// it in `PathImpl.glob` directly
+pub enum GlobIgnoreCase {
+    CaseSensitive,
+    CaseInsensitive,
+}
+
 #[derive(Clone)]
 struct PathImpl {
     entry: DirEntry,
     metadata: Metadata,
-    globs: Vec<Pattern>,
+    globs: Vec<(Pattern, GlobIgnoreCase)>,
 }
 
 impl PathImpl {
@@ -99,7 +109,7 @@ impl PathImpl {
     // this is seriously ugly. We need to pre-create this object
     // since it must look after the compiled glob patterns.
     // But entry needs a valid initialization...
-    fn new(base: &Path, globs: Vec<Pattern>) -> BoxResult<PathImpl> {
+    fn new(base: &Path, globs: Vec<(Pattern, GlobIgnoreCase)>) -> BoxResult<PathImpl> {
         let entry = WalkBuilder::new(base).build().next().unwrap()?;
         let metadata = entry.metadata()?;
         Ok(PathImpl {
@@ -148,7 +158,12 @@ impl PathImpl {
     }
 
     fn matches(&mut self, idx: i64) -> bool {
-        self.globs[idx as usize].matches_path(self.entry.path())
+        let ref pattern = self.globs[idx as usize].0;
+        let ref options = match self.globs[idx as usize].1 {
+            GlobIgnoreCase::CaseSensitive => MatchOptions::new(),
+            GlobIgnoreCase::CaseInsensitive => MatchOptions::default(),
+        };
+        pattern.matches_path_with(self.entry.path(), &options)
     }
 
     fn register(engine: &mut Engine) {
@@ -161,6 +176,7 @@ impl PathImpl {
         engine.register_get("ext",PathImpl::ext);
         engine.register_get("file_name",PathImpl::file_name);
         engine.register_fn("matches",PathImpl::matches);
+        engine.register_fn("matches_ignore_case",PathImpl::matches);
     }
 
 }

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -44,7 +44,7 @@ fn preprocess_numbers(text: &str) -> BoxResult<String> {
 // massage any string arguments of known `methods` of the object `obj`
 fn preprocess_string_arguments<C>(text: &str, obj: &str, methods: &[&str], mut process: C) -> BoxResult<String>
 where C: FnMut(&str,&str) -> BoxResult<String>  {
-    let seek_method_args = Regex::new(&format!("{}{}",obj,r#"\.([[:alpha:]]+)\s*\([^\)]+\)"#))?;
+    let seek_method_args = Regex::new(&format!("{}{}",obj,r#"\.([[:alpha:]_]+)\s*\([^\)]+\)"#))?;
     let seek_string = Regex::new(r#"\s*"([^"]+)"\s*"#)?;
     let mut possible_error: Option<String> = None;
     let res = seek_method_args.replace_all(text, |caps: &Captures| {


### PR DESCRIPTION
equivalent to `find -ipath`. Currently `glob::MatchOptions` only support ASCII-case-insensivity.

Demo:
```
➤ env FINDR_DEBUG= cargo run -- . 'path.matches_ignore_case("*licen*")'
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/findr . 'path.matches_ignore_case("*licen*")'`
numbers path.matches_ignore_case("*licen*")
dates path.matches_ignore_case("*licen*")
fun fn filter(path,date,mode) {
        path.matches_ignore_case(0)
}
globs [(Pattern { original: "*licen*", tokens: [AnySequence, Char('l'), Char('i'), Char('c'), Char('e'), Char('n'), AnySequence], is_recursive: false }, CaseInsensitive)]
./LICENSE.txt
```