### PR TITLE
document workaround to escape space in shortcut

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,7 @@ variations found in the wild.
 
 Furthermore we allow an additional condition after this implied glob
 pattern. If it's `<` or `>`, then the meaning is a path size expression, otherwise
-it's a time expression. You can use `?` to "escape" space in shortcut filters, however this
+it's a time expression. You can use `?` to "escape" space in the glob part, however this
 would match other characters too.
 
 So `findr '.c after last tues'` will give me all C source files modified after last Tuesday,

--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,8 @@ variations found in the wild.
 
 Furthermore we allow an additional condition after this implied glob
 pattern. If it's `<` or `>`, then the meaning is a path size expression, otherwise
-it's a time expression.
+it's a time expression. You can use `?` to "escape" space in shortcut filters, however this
+would match other characters too.
 
 So `findr '.c after last tues'` will give me all C source files modified after last Tuesday,
 and `findr '.doc > 256Kb'` gives all .doc files greater than 256Kb. (The single quotes


### PR DESCRIPTION
I haven't found a better way to resolve this ambiguity though. Maybe pulling in `Rhai`'s parsingfunctionality (eg `\` escaping) can help with this and the function-replacing regex too.